### PR TITLE
chore: migrate from requirements.txt to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "coffeebreak-point-system-plugin"
+version = "0.1.0"
+dependencies = [
+    "httpx>=0.25.0",
+]
+
+[tool.coffeebreak]
+identifier = "coffeebreak-point-system-plugin"
+name = "Point System Plugin"
+description = "Integration with the external point system service for managing user points and leaderboards."
+config_page = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# Point System Plugin Dependencies
-httpx>=0.25.0  # For HTTP client functionality
-


### PR DESCRIPTION
## Summary

- Replaces `requirements.txt` with `pyproject.toml` for dependency management
- Declares `httpx>=0.25.0` as a project dependency
- Adds plugin metadata (`identifier`, `name`, `description`, `config_page`) under `[tool.coffeebreak]`