### PR TITLE
feat: add claim limit scope to transaction templates

### DIFF
--- a/admin/Page.jsx
+++ b/admin/Page.jsx
@@ -295,6 +295,7 @@ function TemplateForm({ initial, activities, onSubmit, onCancel }) {
     activity_id: "",
     description: "",
     claim_limit: 0,
+    claim_limit_mode: "per_user",
   });
 
   useEffect(() => {
@@ -307,6 +308,7 @@ function TemplateForm({ initial, activities, onSubmit, onCancel }) {
         activity_id: initial.activity_id ? String(initial.activity_id) : "",
         description: initial.description ?? "",
         claim_limit: initial.claim_limit ?? 0,
+        claim_limit_mode: initial.claim_limit_mode ?? "per_user",
       });
       return;
     }
@@ -319,6 +321,7 @@ function TemplateForm({ initial, activities, onSubmit, onCancel }) {
       activity_id: "",
       description: "",
       claim_limit: 0,
+      claim_limit_mode: "per_user",
     });
   }, [initial]);
 
@@ -335,6 +338,7 @@ function TemplateForm({ initial, activities, onSubmit, onCancel }) {
       points: form.points_mode === "manual" ? 0 : Number(form.points),
       activity_id: form.activity_id ? Number(form.activity_id) : null,
       claim_limit: form.claim_limit ? Number(form.claim_limit) : 0,
+      claim_limit_mode: form.claim_limit_mode || "per_user",
     });
   };
 
@@ -423,17 +427,33 @@ function TemplateForm({ initial, activities, onSubmit, onCancel }) {
         />
       </div>
 
-      <div className="form-control">
-        <label className="label">
-          <span className="label-text">Claim Limit (0 = unlimited)</span>
-        </label>
-        <input
-          className="input input-bordered w-full"
-          type="number"
-          min="0"
-          value={form.claim_limit}
-          onChange={updateField("claim_limit")}
-        />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">Claim Limit (0 = unlimited)</span>
+          </label>
+          <input
+            className="input input-bordered w-full"
+            type="number"
+            min="0"
+            value={form.claim_limit}
+            onChange={updateField("claim_limit")}
+          />
+        </div>
+
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">Claim Limit Scope</span>
+          </label>
+          <select
+            className="select select-bordered w-full"
+            value={form.claim_limit_mode}
+            onChange={updateField("claim_limit_mode")}
+          >
+            <option value="per_user">Per user</option>
+            <option value="overall">Overall</option>
+          </select>
+        </div>
       </div>
 
       <div className="flex justify-end gap-2 pt-2">
@@ -1242,6 +1262,7 @@ function TemplatesSection({
                 <th>Points</th>
                 <th>Activity</th>
                 <th>Claim Limit</th>
+                <th>Limit Scope</th>
                 <th>Permissions</th>
                 <th>Actions</th>
               </tr>
@@ -1266,6 +1287,7 @@ function TemplatesSection({
                   </td>
                   <td>{template.activity_id ?? "-"}</td>
                   <td>{template.claim_limit === 0 ? "Unlimited" : template.claim_limit}</td>
+                  <td>{template.claim_limit_mode === "overall" ? "Overall" : "Per user"}</td>
                   <td>
                     <button
                       className="btn btn-outline btn-xs"

--- a/models/transaction_template.py
+++ b/models/transaction_template.py
@@ -20,3 +20,9 @@ class TransactionTemplate(Base):
     points = Column(Double, nullable=False)
     description = Column(Text, nullable=True)
     claim_limit = Column(Integer, nullable=True, default=0)
+    claim_limit_mode = Column(
+        String,
+        nullable=False,
+        default="per_user",
+        server_default="per_user",
+    )

--- a/routes/point_system.py
+++ b/routes/point_system.py
@@ -41,8 +41,11 @@ def _raise_upstream(e: UpstreamPointSystemError):
 async def _enforce_activity_claim_limit(
     user_id: str,
     activity_id: int,
+    template_id: int,
     template_name: str,
     claim_limit: Optional[int],
+    claim_limit_mode: Optional[str],
+    template_service: TransactionTemplateService,
 ):
     if claim_limit is None:
         return
@@ -59,6 +62,28 @@ async def _enforce_activity_claim_limit(
         )
 
     if normalized_limit <= 0:
+        return
+
+    normalized_mode = str(claim_limit_mode or "per_user").strip().lower()
+    if normalized_mode not in {"per_user", "overall"}:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Template '{template_name}' has invalid claim_limit_mode '{claim_limit_mode}'. "
+                "Use 'per_user' or 'overall'."
+            ),
+        )
+
+    if normalized_mode == "overall":
+        claims_count = template_service.count_qr_claims_overall(template_id)
+        if claims_count >= normalized_limit:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Claim limit reached for template '{template_name}'. "
+                    f"It allows at most {normalized_limit} claims in total."
+                ),
+            )
         return
 
     history = await PointSystemService.points.get_history(user_id)
@@ -358,8 +383,11 @@ async def add_activity_points(
         await _enforce_activity_claim_limit(
             user_id=user_id,
             activity_id=activity_id,
+            template_id=template.id,
             template_name=template.name,
             claim_limit=template.claim_limit,
+            claim_limit_mode=getattr(template, "claim_limit_mode", "per_user"),
+            template_service=template_service,
         )
 
         transaction = TransactionRequest(
@@ -375,6 +403,12 @@ async def add_activity_points(
         )
 
         if result:
+            template_service.register_qr_claim(
+                template_id=template.id,
+                user_sub=user_id,
+                transaction_id=result.id,
+            )
+
             return {
                 "message": "Activity points added successfully",
                 "activity_id": activity_id,

--- a/routes/transaction_template.py
+++ b/routes/transaction_template.py
@@ -192,6 +192,8 @@ async def execute_template(
     if not service.can_execute_template(template_id, user_info, BYPASS_ROLE):
         raise HTTPException(status_code=403, detail="Access denied")
 
+    service.ensure_claim_limit_available(template, payload.user_id)
+
     transaction_type = (
         TransactionType.ACTIVITY
         if template.activity_id is not None
@@ -222,6 +224,8 @@ async def execute_template(
         )
         if transaction is None:
             raise HTTPException(status_code=502, detail="Failed to execute template")
+
+        service.record_template_claim(template.id, payload.user_id, transaction.id)
         return transaction
     except PointSystemUnavailable as e:
         raise HTTPException(status_code=502, detail=str(e))
@@ -271,23 +275,7 @@ async def claim_template_via_qr(
             detail=f"Template '{template.name}' has invalid points configuration.",
         )
 
-    try:
-        claim_limit = int(template.claim_limit or 0)
-    except (TypeError, ValueError):
-        raise HTTPException(
-            status_code=422,
-            detail=f"Template '{template.name}' has invalid claim_limit value.",
-        )
-    if claim_limit > 0:
-        claims_count = service.count_qr_claims_for_user(template.id, user_sub)
-        if claims_count >= claim_limit:
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    f"Claim limit reached for template '{template.name}'. "
-                    f"You can claim it at most {claim_limit} times."
-                ),
-            )
+    service.ensure_claim_limit_available(template, user_sub)
 
     transaction_type = (
         TransactionType.ACTIVITY

--- a/schemas/transaction_template.py
+++ b/schemas/transaction_template.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -8,6 +8,9 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 class PointsMode(str, Enum):
     AUTOMATIC = "automatic"
     MANUAL = "manual"
+
+
+ClaimLimitMode = Literal["per_user", "overall"]
 
 
 class Base(BaseModel):
@@ -31,7 +34,10 @@ class Base(BaseModel):
     )
     description: Optional[str] = Field(None, description="Template description")
     claim_limit: Optional[int] = Field(
-        0, description="Max claims allowed (0 = unlimited)"
+        0, ge=0, description="Max claims allowed (0 = unlimited)"
+    )
+    claim_limit_mode: ClaimLimitMode = Field(
+        "per_user", description="Claim limit scope: per user or overall"
     )
 
     @model_validator(mode="after")
@@ -50,7 +56,8 @@ class Update(BaseModel):
     points: Optional[int] = Field(None)
     points_mode: Optional[PointsMode] = Field(None)
     description: Optional[str] = Field(None)
-    claim_limit: Optional[int] = Field(None)
+    claim_limit: Optional[int] = Field(None, ge=0)
+    claim_limit_mode: Optional[ClaimLimitMode] = Field(None)
 
 
 class Response(Base):

--- a/services/transaction_template_service.py
+++ b/services/transaction_template_service.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
+import logging
 from typing import List, Optional
 
 from coffeebreak.utils.api import HTTPException
+from sqlalchemy import inspect, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -14,9 +16,52 @@ from ..models.transaction_template_permission import (
 from ..schemas import transaction_template as tp
 
 
+logger = logging.getLogger("coffeebreak.point_system")
+
+
 class TransactionTemplateService:
+    _schema_ready = False
+
     def __init__(self, db: Session):
         self.db: Session = db
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        if TransactionTemplateService._schema_ready:
+            return
+
+        bind = self.db.get_bind()
+        inspector = inspect(bind)
+
+        if "transaction_templates" in inspector.get_table_names():
+            columns = {
+                column["name"]
+                for column in inspector.get_columns("transaction_templates")
+            }
+            if "claim_limit_mode" not in columns:
+                try:
+                    self.db.execute(
+                        text(
+                            "ALTER TABLE transaction_templates "
+                            "ADD COLUMN claim_limit_mode VARCHAR(32) "
+                            "NOT NULL DEFAULT 'per_user'"
+                        )
+                    )
+                    self.db.commit()
+                except Exception:
+                    self.db.rollback()
+                    refreshed_columns = {
+                        column["name"]
+                        for column in inspect(bind).get_columns("transaction_templates")
+                    }
+                    if "claim_limit_mode" not in refreshed_columns:
+                        logger.exception(
+                            "Failed adding claim_limit_mode column to transaction_templates"
+                        )
+                        raise
+
+        TransactionTemplateQrClaim.__table__.create(bind=bind, checkfirst=True)
+        TransactionTemplateService._schema_ready = True
 
     def _active_query(self):
         return self.db.query(TransactionTemplate).filter(
@@ -39,6 +84,46 @@ class TransactionTemplateService:
             status_code=422,
             detail="points_mode must be either 'automatic' or 'manual'.",
         )
+
+    @staticmethod
+    def _normalize_claim_limit_mode(value) -> str:
+        if value is None:
+            return "per_user"
+
+        if hasattr(value, "value"):
+            value = value.value
+
+        mode = str(value).strip().lower()
+        if mode in {"per_user", "overall"}:
+            return mode
+
+        raise HTTPException(
+            status_code=422,
+            detail="claim_limit_mode must be either 'per_user' or 'overall'.",
+        )
+
+    @staticmethod
+    def _normalize_claim_limit(value) -> int:
+        if value is None:
+            return 0
+
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Invalid claim_limit '{value}'. "
+                    "Use 0 for unlimited or a positive integer."
+                ),
+            )
+
+        if normalized < 0:
+            raise HTTPException(
+                status_code=422, detail="claim_limit cannot be negative."
+            )
+
+        return normalized
 
     @staticmethod
     def _normalize_qr_enabled(value) -> bool:
@@ -92,6 +177,12 @@ class TransactionTemplateService:
         template_data["qr_enabled"] = self._normalize_qr_enabled(
             template_data.get("qr_enabled")
         )
+        template_data["claim_limit"] = self._normalize_claim_limit(
+            template_data.get("claim_limit")
+        )
+        template_data["claim_limit_mode"] = self._normalize_claim_limit_mode(
+            template_data.get("claim_limit_mode")
+        )
 
         db_template = TransactionTemplate(**template_data)
 
@@ -142,6 +233,12 @@ class TransactionTemplateService:
         db_template.points = points_value
         db_template.qr_enabled = self._normalize_qr_enabled(
             getattr(db_template, "qr_enabled", False)
+        )
+        db_template.claim_limit = self._normalize_claim_limit(
+            getattr(db_template, "claim_limit", 0)
+        )
+        db_template.claim_limit_mode = self._normalize_claim_limit_mode(
+            getattr(db_template, "claim_limit_mode", "per_user")
         )
 
         try:
@@ -326,6 +423,58 @@ class TransactionTemplateService:
                 TransactionTemplateQrClaim.user_sub == user_sub,
             )
             .count()
+        )
+
+    def count_qr_claims_overall(self, template_id: int) -> int:
+        return (
+            self.db.query(TransactionTemplateQrClaim.id)
+            .filter(TransactionTemplateQrClaim.template_id == template_id)
+            .count()
+        )
+
+    def ensure_claim_limit_available(
+        self, template: TransactionTemplate, user_id: str
+    ) -> None:
+        claim_limit = self._normalize_claim_limit(getattr(template, "claim_limit", 0))
+        if claim_limit <= 0:
+            return
+
+        claim_limit_mode = self._normalize_claim_limit_mode(
+            getattr(template, "claim_limit_mode", "per_user")
+        )
+
+        if claim_limit_mode == "overall":
+            claims_count = self.count_qr_claims_overall(template.id)
+            if claims_count >= claim_limit:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Claim limit reached for template '{template.name}'. "
+                        f"This template allows at most {claim_limit} claims in total."
+                    ),
+                )
+            return
+
+        claims_count = self.count_qr_claims_for_user(template.id, user_id)
+        if claims_count >= claim_limit:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Claim limit reached for template '{template.name}'. "
+                    f"You can claim it at most {claim_limit} times."
+                ),
+            )
+
+    def record_template_claim(
+        self,
+        template_id: int,
+        user_id: str,
+        point_transaction_id: Optional[int],
+    ) -> None:
+        self.register_qr_claim(
+            template_id=template_id,
+            user_sub=user_id,
+            transaction_id=point_transaction_id,
         )
 
     def register_qr_claim(

--- a/services/transaction_template_service.py
+++ b/services/transaction_template_service.py
@@ -33,32 +33,46 @@ class TransactionTemplateService:
         bind = self.db.get_bind()
         inspector = inspect(bind)
 
-        if "transaction_templates" in inspector.get_table_names():
-            columns = {
+        def ensure_column(column_name: str, ddl: str) -> None:
+            current_columns = {
                 column["name"]
-                for column in inspector.get_columns("transaction_templates")
+                for column in inspect(bind).get_columns("transaction_templates")
             }
-            if "claim_limit_mode" not in columns:
-                try:
-                    self.db.execute(
-                        text(
-                            "ALTER TABLE transaction_templates "
-                            "ADD COLUMN claim_limit_mode VARCHAR(32) "
-                            "NOT NULL DEFAULT 'per_user'"
-                        )
+            if column_name in current_columns:
+                return
+
+            try:
+                self.db.execute(text(ddl))
+                self.db.commit()
+            except Exception:
+                self.db.rollback()
+                refreshed_columns = {
+                    column["name"]
+                    for column in inspect(bind).get_columns("transaction_templates")
+                }
+                if column_name not in refreshed_columns:
+                    logger.exception(
+                        "Failed adding column '%s' to transaction_templates",
+                        column_name,
                     )
-                    self.db.commit()
-                except Exception:
-                    self.db.rollback()
-                    refreshed_columns = {
-                        column["name"]
-                        for column in inspect(bind).get_columns("transaction_templates")
-                    }
-                    if "claim_limit_mode" not in refreshed_columns:
-                        logger.exception(
-                            "Failed adding claim_limit_mode column to transaction_templates"
-                        )
-                        raise
+                    raise
+
+        if "transaction_templates" in inspector.get_table_names():
+            ensure_column(
+                "qr_enabled",
+                "ALTER TABLE transaction_templates "
+                "ADD COLUMN qr_enabled BOOLEAN NOT NULL DEFAULT false",
+            )
+            ensure_column(
+                "points_mode",
+                "ALTER TABLE transaction_templates "
+                "ADD COLUMN points_mode VARCHAR(32) NOT NULL DEFAULT 'automatic'",
+            )
+            ensure_column(
+                "claim_limit_mode",
+                "ALTER TABLE transaction_templates "
+                "ADD COLUMN claim_limit_mode VARCHAR(32) NOT NULL DEFAULT 'per_user'",
+            )
 
         TransactionTemplateQrClaim.__table__.create(bind=bind, checkfirst=True)
         TransactionTemplateService._schema_ready = True


### PR DESCRIPTION
## Summary
- adds `claim_limit_mode` to transaction templates with default `per_user` and new `overall` option
- enforces claim limits in template execute, QR claim, and activity award flows
- keeps existing per-user behavior as default and adds DB-safe schema bootstrap for existing installs
- updates admin template form/table to configure and display claim limit scope

## Validation
- `python3 -m py_compile models/transaction_template.py schemas/transaction_template.py services/transaction_template_service.py routes/transaction_template.py routes/point_system.py`