### PR TITLE
fix: unblock staff QR awards for template managers

### DIFF
--- a/components/staff/StaffPage.jsx
+++ b/components/staff/StaffPage.jsx
@@ -427,7 +427,14 @@ export default function StaffPage({ title = "Staff QR Scanner" }) {
         stopScanner();
         await onVerifiedUser(String(userId));
       } catch (error) {
-        setScannerError(getErrorMessage(error, "Invalid or expired QR code."));
+        const status = error?.response?.status;
+        const msg =
+          status === 403
+            ? "QR code scanned successfully but you do not have permission to award points for this activity."
+            : status === 401
+            ? "You must be logged in to scan QR codes."
+            : getErrorMessage(error, "Invalid or expired QR code.");
+        setScannerError(msg);
       } finally {
         setIsVerifying(false);
         verifyInProgressRef.current = false;
@@ -629,7 +636,7 @@ export default function StaffPage({ title = "Staff QR Scanner" }) {
 
       try {
         const api = getApi();
-        const response = await api.get("/coffeebreak-point-system-plugin/transaction-template");
+        const response = await api.get("/coffeebreak-point-system-plugin/transaction-template/accessible");
         const templates = Array.isArray(response.data) ? response.data : [];
 
         const grouped = {};
@@ -705,7 +712,12 @@ export default function StaffPage({ title = "Staff QR Scanner" }) {
         setSuccessMessage(`Successfully awarded ${parsedPoints} points.`);
         setStep(STEP_SUCCESS);
       } catch (error) {
-        setFlowError(getErrorMessage(error, "Failed to award manual points."));
+        const status = error?.response?.status;
+        setFlowError(
+          status === 403
+            ? "You do not have permission to award manual points."
+            : getErrorMessage(error, "Failed to award manual points.")
+        );
       } finally {
         setIsSubmitting(false);
       }

--- a/routes/point_system.py
+++ b/routes/point_system.py
@@ -260,7 +260,7 @@ async def add_points(
     user_id: str = Path(..., description="User identifier"),
     transaction: TransactionRequest = Body(...),
     transaction_type: TransactionType = TransactionType.MANUAL,
-    _: dict = Depends(check_role([BYPASS_ROLE])),
+    _: dict = Depends(check_role([ROLE, BYPASS_ROLE])),
 ):
     """
     Add points to user.

--- a/routes/transaction_template.py
+++ b/routes/transaction_template.py
@@ -112,6 +112,20 @@ async def get_all_templates(
     return service.list_templates()
 
 
+@router.get("/accessible", response_model=List[Response])
+async def get_accessible_templates(
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(get_current_user()),
+):
+    """Return templates the caller can execute (role or ACL match)."""
+    service = TransactionTemplateService(db)
+    return [
+        t
+        for t in service.list_templates()
+        if service.can_execute_template(t.id, user_info, BYPASS_ROLE)
+    ]
+
+
 @router.post("", response_model=Response)
 async def create_template(
     template: Base,


### PR DESCRIPTION
## Summary
- allow manual point awards for users with `manage_transaction_templates` (in addition to bypass role)
- add `GET /transaction-template/accessible` for ACL-aware template loading in staff scanner flow
- improve staff scanner error messages to distinguish permission/auth failures from invalid QR payloads