### PR TITLE
fix: enforce per-template claim limits for activity templates

### DIFF
--- a/models/transaction_template_qr_claim_v2.py
+++ b/models/transaction_template_qr_claim_v2.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, DateTime, String
+from sqlalchemy.sql import func
+
+from coffeebreak.dependencies.database import Base
+
+
+class TransactionTemplateQrClaimV2(Base):
+    __tablename__ = "transaction_template_qr_claims_v2"
+
+    id = Column(Integer, primary_key=True, index=True)
+    template_id = Column(Integer, nullable=False, index=True)
+    user_sub = Column(String, nullable=False, index=True)
+    transaction_id = Column(Integer, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/routes/point_system.py
+++ b/routes/point_system.py
@@ -86,21 +86,14 @@ async def _enforce_activity_claim_limit(
             )
         return
 
-    history = await PointSystemService.points.get_history(user_id)
-    claims_count = sum(
-        1
-        for tx in history
-        if tx.transaction_type == TransactionType.ACTIVITY
-        and tx.activity_id == activity_id
-        and tx.points > 0
-    )
+    claims_count = template_service.count_qr_claims_for_user(template_id, user_id)
 
     if claims_count >= normalized_limit:
         raise HTTPException(
             status_code=409,
             detail=(
-                f"Claim limit reached for activity {activity_id}. "
-                f"Template '{template_name}' allows at most {normalized_limit} successful claims per participant."
+                f"Claim limit reached for template '{template_name}'. "
+                f"It allows at most {normalized_limit} successful claims per participant."
             ),
         )
 

--- a/services/transaction_template_service.py
+++ b/services/transaction_template_service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from ..models.transaction_template import TransactionTemplate
 from ..models.transaction_template_qr_claim import TransactionTemplateQrClaim
+from ..models.transaction_template_qr_claim_v2 import TransactionTemplateQrClaimV2
 from ..models.transaction_template_permission import (
     TransactionTemplateUserPermission,
     TransactionTemplateRolePermission,
@@ -431,18 +432,18 @@ class TransactionTemplateService:
 
     def count_qr_claims_for_user(self, template_id: int, user_sub: str) -> int:
         return (
-            self.db.query(TransactionTemplateQrClaim.id)
+            self.db.query(TransactionTemplateQrClaimV2.id)
             .filter(
-                TransactionTemplateQrClaim.template_id == template_id,
-                TransactionTemplateQrClaim.user_sub == user_sub,
+                TransactionTemplateQrClaimV2.template_id == template_id,
+                TransactionTemplateQrClaimV2.user_sub == user_sub,
             )
             .count()
         )
 
     def count_qr_claims_overall(self, template_id: int) -> int:
         return (
-            self.db.query(TransactionTemplateQrClaim.id)
-            .filter(TransactionTemplateQrClaim.template_id == template_id)
+            self.db.query(TransactionTemplateQrClaimV2.id)
+            .filter(TransactionTemplateQrClaimV2.template_id == template_id)
             .count()
         )
 
@@ -493,8 +494,8 @@ class TransactionTemplateService:
 
     def register_qr_claim(
         self, template_id: int, user_sub: str, transaction_id: Optional[int] = None
-    ) -> TransactionTemplateQrClaim:
-        claim = TransactionTemplateQrClaim(
+    ) -> TransactionTemplateQrClaimV2:
+        claim = TransactionTemplateQrClaimV2(
             template_id=template_id,
             user_sub=user_sub,
             transaction_id=transaction_id,


### PR DESCRIPTION
## Summary
- add a new `TransactionTemplateQrClaimV2` model/table for fresh claim accounting without mutating existing data
- switch claim counting and claim registration to V2 records in `TransactionTemplateService`
- enforce per-user claim limits in the staff activity route using template-specific claim counts instead of activity-wide history