### PR TITLE
feat: invert sorting for transactions and update pagination logic in …

### DIFF
--- a/components/MyPointsPage.jsx
+++ b/components/MyPointsPage.jsx
@@ -99,7 +99,10 @@ export default function MyPointsPage({
             
             // Handle both array response and paginated response
             if (Array.isArray(transactionsResponse.data)) {
-              setTransactions(transactionsResponse.data);
+              const sortedTransactions = [...transactionsResponse.data].sort(
+                (a, b) => new Date(b.created_at) - new Date(a.created_at)
+              );
+              setTransactions(sortedTransactions);
               setTotalTransactions(transactionsResponse.data.length);
             } else if (transactionsResponse.data?.items) {
               // Paginated response with items and total
@@ -147,15 +150,14 @@ export default function MyPointsPage({
 
   useEffect(() => {
     if (currentUserId) {
-      setCurrentPage(1); // Reset to first page when user changes
       void loadUserData();
     }
-  }, [currentUserId, loadUserData]);
+  }, [currentUserId, currentPage, loadUserData]);
 
-  // Reset to first page when transaction limit changes
+  // Reset to first page when user or transaction limit changes
   useEffect(() => {
     setCurrentPage(1);
-  }, [transaction_limit]);
+  }, [currentUserId, transaction_limit]);
 
   if (!currentUserId) {
     return (


### PR DESCRIPTION
This pull request improves the user experience and data consistency on the `MyPointsPage` by ensuring transactions are always displayed in descending order by creation date and by refining how pagination resets when the user or transaction limit changes.

**Transaction sorting improvements:**

* Transactions are now sorted by `created_at` in descending order before being set in state, ensuring the newest transactions appear first.

**Pagination and page reset logic:**

* The page reset logic now triggers when either the `currentUserId` or `transaction_limit` changes, so users always start on the first page after these updates.
* The dependency array for the effect that loads user data now includes `currentPage`, ensuring user data reloads properly on page changes.…